### PR TITLE
Require Send and Sync traits on all boxed `dyn Error`s

### DIFF
--- a/src/bin/level4.rs
+++ b/src/bin/level4.rs
@@ -15,9 +15,11 @@ impl Stats {
     }
 
     fn bytes_per_sec(&self) -> Option<f64> {
-        match self.duration {
-            0 => None,
-            _ => (self.number_of_bytes as f64) / self.duration.as_secs_f64(),
+        let secs = self.duration.as_secs_f64();
+        if secs < 0.001 {
+            None
+        } else {
+            Some(self.number_of_bytes as f64 / secs)
         }
     }
 }

--- a/src/bin/level8.rs
+++ b/src/bin/level8.rs
@@ -27,7 +27,7 @@ impl Stats {
     }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let first_arg = std::env::args().nth(1).ok_or(Error::new(ErrorKind::NotFound, "File name is missing"))?;
     println!("Args: {}", first_arg);
 
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //urls.into_iter().for_each(fetch_status);
     for url in urls {
         let shared_stat = shared_stat.clone();
-        let thread = std::thread::spawn(move || -> Result<(), Box<dyn std::error::Error>> {
+        let thread = std::thread::spawn(move || -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             let stat = fetch_status(&url)?;
             shared_stat.lock().unwrap().aggregate(&stat);
             Ok(())
@@ -77,7 +77,7 @@ fn read_file(filename: &str) -> Result<Vec<String>, std::io::Error> {
 }
 
 //fn fetch_status(url: &String) -> Result<Stats, Box<dyn std::error::Error + Send>> {
-fn fetch_status(url: &String) -> Result<Stats, Box<dyn std::error::Error + Send>> {
+fn fetch_status(url: &String) -> Result<Stats, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let start_time = Instant::now();
     let client = reqwest::blocking::Client::new();
     //let resp = client.get(url).send()?;


### PR DESCRIPTION
There's no implementation of `From<dyn Error + Send> for Box<dyn Error + Send>` but there is one of `From<dyn Error + Send + Sync> for `Box<dyn Error + Send + Sync>` so use that. Somewhat surprisingly, the error types *are* Sync.

https://doc.rust-lang.org/stable/std/convert/trait.From.html#impl-From%3CE%3E-1