### PR TITLE
Use thiserror for error handling

### DIFF
--- a/src/bin/level4.rs
+++ b/src/bin/level4.rs
@@ -15,9 +15,11 @@ impl Stats {
     }
 
     fn bytes_per_sec(&self) -> Option<f64> {
-        match self.duration {
-            0 => None,
-            _ => (self.number_of_bytes as f64) / self.duration.as_secs_f64(),
+        let secs = self.duration.as_secs_f64();
+        if secs < 0.001 {
+            None
+        } else {
+            Some(self.number_of_bytes as f64 / secs)
         }
     }
 }


### PR DESCRIPTION
Create an enum containing all possible error types in our app as variants. Since we don't use trait objects here (i.e. no `dyn Trait`), we don't need to worry about implicit traits like Send, since the compiler always knows whether a particular concrete type implements them.